### PR TITLE
patch(bridge\inventory & modules\inventory): add built inventory.getItemImage function to modules

### DIFF
--- a/bridge/billing/jim-payments/client.lua
+++ b/bridge/billing/jim-payments/client.lua
@@ -5,7 +5,7 @@ function billing.open(data)
         job = data.job,
         gang = data.gang,
         coords = data.coords.xyz,
-        img = "<center><p><img src="..data.img.." width=100px></p>"
+        img = data.img or "",
     })
 end
 

--- a/bridge/inventory/ox_inventory/client.lua
+++ b/bridge/inventory/ox_inventory/client.lua
@@ -35,6 +35,10 @@ function inventory.hasItem(item, count, metadata)
     return false, "You do not have enough: " .. item
 end
 
+function inventory.getItemImage(item)
+    return 'https://cfx-nui-ox_inventory/web/images/'..item..'.png'
+end
+
 function inventory.findItem(item, metadata)
     return ox_inventory:Search('slots', item, metadata)
 end

--- a/bridge/inventory/qb-inventory/client.lua
+++ b/bridge/inventory/qb-inventory/client.lua
@@ -20,6 +20,7 @@ end
 function inventory.getItemImage(item)
     return 'https://cfx-nui-qb-inventory/html/images/'..item..'.png'
 end
+
 function inventory.getPlayerInventory()
     local PlayerInv = QBCore.Functions.GetPlayerData().items
     if not PlayerInv then

--- a/modules/inventory/client.lua
+++ b/modules/inventory/client.lua
@@ -28,6 +28,10 @@ function zutils.inventory.findItem(item, metadata)
     return inventory.findItem(item, metadata)
 end
 
+function zutils.inventory.getItemImage(item)
+    return inventory.getItemImage(item)
+end
+
 function zutils.inventory.count(item, metadata)
     return inventory.count(item, metadata)
 end


### PR DESCRIPTION
This adds getItemImage to the module it was already built in qb-inventory, but never added as a functionality for ox_inventory or the other inventories. This adds this to the module to be used. I also added ox_inventories function.